### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # OpenFF_Bilayer
 
-OpenFF pure POPC and POPE bilayers. 128 lipid systems hydrated with 5000 TIP3P waters. Standard conditions: 1 Bar, 300 K, and no ions. Methods directories contain equilibration files as well as relevant trajectories and topologies used for analysis. Trajectories contain the 200 ns MD production simulations with data saved every 10 ps. Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method. MacRog POPC bilayer.gro was reformatted for OpenFF POPC bilayer, then equilibrated for 25 ns. POPE bilayer was built using Packmol, then equilibrated for 13 ns. Both systems were determined to be fully equilibrated by the plateau of temperature, pressure, density, and potential energy.
+OpenFF pure POPC and POPE bilayers. 128 lipid systems hydrated with 5000 TIP3P waters. 
+  - Simulation conditions: 1 Bar, 300 K, and no ions.
+  - Methods directories contain equilibration files as well as relevant trajectories and topologies used for analysis.
+  - Trajectories contain the 200 ns MD production simulations with data saved every 10 ps.
+  - Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method.  Residue names were changed to assemble the final .topology.
+  - MacRog POPC bilayer.gro was reformatted for OpenFF POPC bilayer, then equilibrated for 25 ns.
+  - POPE bilayer.gro was built using Packmol, then equilibrated for 13 ns.
+  - Both systems were determined to be equilibrated by the plateau of instantaneous temperaure temperature, pressure, density, and potential energy.
 
 A control using MacRog forcefields and OpenFF methods was run and compared to its existing simulation analysis in the NMRLipids Databank. MacRog was chosen for its similar nomenclature and atom ordering for ease of topology creation.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenFF pure POPC and POPE bilayers. 128 lipid systems hydrated with 5000 TIP3P w
   - Simulation conditions: 1 Bar, 300 K, and no ions.
   - Methods directories contain equilibration files as well as relevant trajectories and topologies used for analysis.
   - Trajectories contain the 200 ns MD production simulations with data saved every 10 ps.
-  - Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method.  Residue names were changed to assemble the final topology.
+  - Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method. Residue names were changed to assemble the final topology.
   - MacRog POPC bilayer.gro was reformatted for OpenFF POPC bilayer, then equilibrated for 25 ns.
   - POPE bilayer.gro was built using Packmol, then equilibrated for 13 ns.
   - Both systems were determined to be equilibrated by the plateau of instantaneous temperature, pressure, density, and potential energy.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ OpenFF pure POPC and POPE bilayers. 128 lipid systems hydrated with 5000 TIP3P w
   - Simulation conditions: 1 Bar, 300 K, and no ions.
   - Methods directories contain equilibration files as well as relevant trajectories and topologies used for analysis.
   - Trajectories contain the 200 ns MD production simulations with data saved every 10 ps.
-  - Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method.  Residue names were changed to assemble the final .topology.
+  - Parameter directories contain parametrization of POPC and POPE molecules using the OpenFF Toolkit and Interchange conversion method.  Residue names were changed to assemble the final topology.
   - MacRog POPC bilayer.gro was reformatted for OpenFF POPC bilayer, then equilibrated for 25 ns.
   - POPE bilayer.gro was built using Packmol, then equilibrated for 13 ns.
-  - Both systems were determined to be equilibrated by the plateau of instantaneous temperaure temperature, pressure, density, and potential energy.
+  - Both systems were determined to be equilibrated by the plateau of instantaneous temperature, pressure, density, and potential energy.
 
 A control using MacRog forcefields and OpenFF methods was run and compared to its existing simulation analysis in the NMRLipids Databank. MacRog was chosen for its similar nomenclature and atom ordering for ease of topology creation.
 


### PR DESCRIPTION
Added more detail and formatting.

A couple of other things that should be added.
- mention what reformatting was done for the POPC .gro file.
- Include the PackMol function call so build can be made reproducible.
- Mention where the TIP3P files came from (I think CHARMM-GUI - the hydrogen epsilon is 0.1, which is not standard, though should no change the results in any statistically meaninful way), and the provenance of any other files (GROMACS .mdp files for other systems on NMRLipid databank? Somewhere else? ) 