### PR TITLE
Fix typo in force field loading

### DIFF
--- a/New_Procedure/Procedure/SMILES_interchange.ipynb
+++ b/New_Procedure/Procedure/SMILES_interchange.ipynb
@@ -439,7 +439,7 @@
    "source": [
     "\n",
     "# Define ff versions\n",
-    "forcefield = ForceField(\"openff-2.1.0.offxml, tip3p.offxml\")\n",
+    "forcefield = ForceField(\"openff-2.1.0.offxml\", \"tip3p.offxml\")\n",
     "\n",
     "system = Topology.from_pdb(\"bilayer.pdb\")\n",
     "\n",


### PR DESCRIPTION
Here's a small yet critical typo in force field loading - the constructor needs the different files as lists of strings and won't attempt to separate them out if a single string is passed through.